### PR TITLE
Kinetica support

### DIFF
--- a/flyway-community-db-support/pom.xml
+++ b/flyway-community-db-support/pom.xml
@@ -46,6 +46,12 @@
             <version>${version.junit}</version>
         </dependency>
         <!-- JDBC drivers -->
+        <!-- https://mvnrepository.com/artifact/com.kinetica/kinetica-jdbc -->
+        <dependency>
+            <groupId>com.kinetica</groupId>
+            <artifactId>kinetica-jdbc</artifactId>
+            <version>7.1.6.1</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.ignite</groupId>
             <artifactId>ignite-core</artifactId>

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaConnection.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaConnection.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.kinetica;
+
+import org.flywaydb.community.database.ignite.thin.IgniteThinDatabase;
+import org.flywaydb.community.database.ignite.thin.IgniteThinSchema;
+import org.flywaydb.core.internal.database.base.Connection;
+import org.flywaydb.core.internal.database.base.Schema;
+
+import java.sql.SQLException;
+
+public class KineticaConnection extends Connection<KineticaDatabase> {
+
+    KineticaConnection(KineticaDatabase database, java.sql.Connection connection) {
+        super(database, connection);
+    }
+
+    @Override
+    public void doRestoreOriginalState() throws SQLException {}
+
+    @Override
+    public void doChangeCurrentSchemaOrSearchPathTo(String schema) throws SQLException {
+        getJdbcConnection().setSchema(schema);
+    }
+
+    @Override
+    public Schema getSchema(String name) {
+        return new KineticaSchema(jdbcTemplate, database, name);
+    }
+
+    @Override
+    protected String getCurrentSchemaNameOrSearchPath() throws SQLException {
+        return getJdbcConnection().getSchema();
+    }
+}

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaDatabase.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaDatabase.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.kinetica;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+
+import java.sql.Connection;
+
+
+public class KineticaDatabase extends Database {
+
+    public KineticaDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        super(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    protected KineticaConnection doGetConnection(Connection connection) {
+        return new KineticaConnection(this, connection);
+    }
+
+    @Override
+    public final void ensureSupported() {
+        notifyDatabaseIsNotFormallySupported();
+    }
+
+    @Override
+    public String getRawCreateScript(Table table, boolean baseline) {
+        return "CREATE REPLICATED TABLE " + table + " (\n" +
+                "    \"installed_rank\" INT NOT NULL,\n" +
+                "    \"version\" VARCHAR(50),\n" +
+                "    \"description\" VARCHAR(200) NOT NULL,\n" +
+                "    \"type\" VARCHAR(20) NOT NULL,\n" +
+                "    \"script\" VARCHAR(1000) NOT NULL,\n" +
+                "    \"checksum\" INT,\n" +
+                "    \"installed_by\" VARCHAR(100) NOT NULL,\n" +
+                "    \"installed_on\" TIMESTAMP NOT NULL,\n" +
+                "    \"execution_time\" INT NOT NULL,\n" +
+                "    \"success\" tinyint NOT NULL,\n" +
+                "     PRIMARY KEY (\"installed_rank\")\n" +
+                ") ;\n" +
+                (baseline ? getBaselineStatement(table) + ";\n" : "") +
+                "ALTER TABLE ADD INDEX public." + table + " (\"success\");";
+    }
+
+    @Override
+    public String getSelectStatement(Table table) {
+        return "SELECT " + quote("installed_rank")
+                + "," + quote("version")
+                + "," + quote("description")
+                + "," + quote("type")
+                + "," + quote("script")
+                + "," + quote("checksum")
+                + "," + quote("installed_on")
+                + "," + quote("installed_by")
+                + "," + quote("execution_time")
+                + "," + quote("success")
+                + " FROM " + table
+                // Ignore special table created marker
+                + " WHERE " + quote("type") + " != 'TABLE'"
+                + " AND " + quote("installed_rank") + " > ?"
+                + " ORDER BY " + quote("installed_rank");
+    }
+
+    @Override
+    public String getInsertStatement(Table table) {
+        java.util.Date t = new java.util.Date ();
+
+        return "INSERT INTO " + table
+                + " (" + quote("installed_rank")
+                + ", " + quote("version")
+                + ", " + quote("description")
+                + ", " + quote("type")
+                + ", " + quote("script")
+                + ", " + quote("checksum")
+                + ", " + quote("installed_by")
+                + ", " + quote("installed_on")
+                + ", " + quote("execution_time")
+                + ", " + quote("success")
+                + ")"
+                + " VALUES (?, ?, ?, ?, ?, ?, ?," +t.getTime()+", ?,?)";
+    }
+
+    @Override
+    public boolean supportsDdlTransactions() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsChangingCurrentSchema() {
+        return false;
+    }
+
+    @Override
+    public String getBooleanTrue() {
+        return "1";
+    }
+
+    @Override
+    public String getBooleanFalse() {
+        return "0";
+    }
+
+    @Override
+    public boolean catalogIsSchema() {
+        return false;
+    }
+
+
+}

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaDatabaseType.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaDatabaseType.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.kinetica;
+
+import org.flywaydb.core.api.ResourceProvider;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.BaseDatabaseType;
+import org.flywaydb.core.internal.jdbc.ExecutionTemplate;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.jdbc.TransactionalExecutionTemplate;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+import java.sql.Connection;
+import java.sql.Types;
+
+
+public class KineticaDatabaseType extends BaseDatabaseType {
+
+    @Override
+    public String getName() {
+        return "kinetica";
+    }
+
+    @Override
+    public int getNullType() {
+        return Types.VARCHAR;
+    }
+
+    @Override
+    public boolean handlesJDBCUrl(String url) {
+        return url.startsWith("jdbc:kinetica:");
+    }
+
+    @Override
+    public KineticaDatabase createDatabase(Configuration configuration, boolean printInfo, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        return  createDatabase(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    public KineticaDatabase createDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        return new KineticaDatabase(configuration,jdbcConnectionFactory,statementInterceptor);
+    }
+
+    @Override
+    public String getDriverClass(String url, ClassLoader classLoader) {
+        return "com.kinetica.jdbc.Driver";
+    }
+
+    @Override
+    public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
+        return databaseProductName.startsWith("Kinetica");
+    }
+
+    @Override
+    public Parser createParser(Configuration configuration, ResourceProvider resourceProvider, ParsingContext parsingContext) {
+        return new KineticaParser(configuration, parsingContext);
+    }
+
+    @Override
+    public ExecutionTemplate createTransactionalExecutionTemplate(Connection connection, boolean rollbackOnException) {
+        final KineticaExecutionTemplate kineticaExecutionTemplate = new KineticaExecutionTemplate(connection, rollbackOnException);
+        return kineticaExecutionTemplate;
+    }
+}

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaDatabaseType.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaDatabaseType.java
@@ -72,7 +72,7 @@ public class KineticaDatabaseType extends BaseDatabaseType {
 
     @Override
     public ExecutionTemplate createTransactionalExecutionTemplate(Connection connection, boolean rollbackOnException) {
-        final KineticaExecutionTemplate kineticaExecutionTemplate = new KineticaExecutionTemplate(connection, rollbackOnException);
+        final KineticaExecutionTemplate kineticaExecutionTemplate = new KineticaExecutionTemplate();
         return kineticaExecutionTemplate;
     }
 }

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaExecutionTemplate.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaExecutionTemplate.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.kinetica;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
+import org.flywaydb.core.internal.jdbc.ExecutionTemplate;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.Callable;
+
+public class KineticaExecutionTemplate implements ExecutionTemplate {
+
+    /**
+     * The connection to the database
+     */
+    private final Connection connection;
+
+    /**
+     * Whether to roll back the transaction when an exception is thrown.
+     */
+    private final boolean rollbackOnException;
+
+    public KineticaExecutionTemplate(Connection connection, boolean rollbackOnException) {
+        this.connection = connection;
+        this.rollbackOnException = rollbackOnException;
+    }
+
+    /**
+     * Executes this callback.
+     * This method is an override to remove all transactional (commits, rollbacks,etc) that are not supported in Kinetica.
+     *
+     * @param callback The callback to execute.
+     * @return The result of the NON transaction KINETICA code.
+     */
+    @Override
+    public <T> T execute(Callable<T> callback) {
+        boolean oldAutocommit = true;
+
+
+        try {
+            T result = callback.call();
+            return result;
+        } catch (Exception e) {
+            RuntimeException rethrow;
+            if (e instanceof SQLException) {
+                rethrow = new FlywaySqlException("Unable to commit transaction", (SQLException) e);
+            } else if (e instanceof RuntimeException) {
+                rethrow = (RuntimeException) e;
+            } else {
+                rethrow = new FlywayException(e);
+            }
+
+            throw rethrow;
+        }
+    }
+}

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaExecutionTemplate.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaExecutionTemplate.java
@@ -18,27 +18,10 @@ package org.flywaydb.community.database.kinetica;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.internal.exception.FlywaySqlException;
 import org.flywaydb.core.internal.jdbc.ExecutionTemplate;
-
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.concurrent.Callable;
 
 public class KineticaExecutionTemplate implements ExecutionTemplate {
-
-    /**
-     * The connection to the database
-     */
-    private final Connection connection;
-
-    /**
-     * Whether to roll back the transaction when an exception is thrown.
-     */
-    private final boolean rollbackOnException;
-
-    public KineticaExecutionTemplate(Connection connection, boolean rollbackOnException) {
-        this.connection = connection;
-        this.rollbackOnException = rollbackOnException;
-    }
 
     /**
      * Executes this callback.
@@ -49,8 +32,6 @@ public class KineticaExecutionTemplate implements ExecutionTemplate {
      */
     @Override
     public <T> T execute(Callable<T> callback) {
-        boolean oldAutocommit = true;
-
 
         try {
             T result = callback.call();
@@ -58,7 +39,7 @@ public class KineticaExecutionTemplate implements ExecutionTemplate {
         } catch (Exception e) {
             RuntimeException rethrow;
             if (e instanceof SQLException) {
-                rethrow = new FlywaySqlException("Unable to commit transaction", (SQLException) e);
+                rethrow = new FlywaySqlException("Unable to execute SQL statement", (SQLException) e);
             } else if (e instanceof RuntimeException) {
                 rethrow = (RuntimeException) e;
             } else {

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaParser.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaParser.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.kinetica;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+
+public class KineticaParser extends Parser {
+
+    public KineticaParser(Configuration configuration, ParsingContext parsingContext) {
+        super(configuration, parsingContext, 2);
+    }
+
+}

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaSchema.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaSchema.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.kinetica;
+
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+import java.sql.SQLException;
+import java.util.List;
+
+public class KineticaSchema extends Schema<KineticaDatabase,KineticaTable> {
+
+
+    /**
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database     The database-specific support.
+     * @param name         The name of the schema.
+     */
+    public KineticaSchema(JdbcTemplate jdbcTemplate, KineticaDatabase database, String name) {
+        super(jdbcTemplate, database, name);
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME=?", name) > 0;
+    }
+
+    @Override
+    protected boolean doEmpty() throws SQLException {
+        return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM INFORMATION_SCHEMA.SCHEMATA") == 0;
+
+    }
+
+    @Override
+    protected void doCreate() throws SQLException {
+        jdbcTemplate.execute("CREATE SCHEMA " + name);
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        jdbcTemplate.execute("DROP SCHEMA " + name);
+
+    }
+
+    @Override
+    protected void doClean() throws SQLException {
+      //
+    }
+
+    @Override
+    protected KineticaTable[] doAllTables() throws SQLException {
+        String query = "select table_name from information_schema.tables where table_schema= '"+name +"'";
+        List<String> tables = jdbcTemplate.queryForStringList(query, name);
+        KineticaTable[]  kineticaTables = new KineticaTable[tables.size()];
+        int index = 0;
+        for (String table: tables) {
+            kineticaTables[index] = new KineticaTable(jdbcTemplate, database, this, table);
+            index++;
+        }
+        return kineticaTables;
+    }
+
+
+    @Override
+    public Table getTable(String tableName) {
+        return new KineticaTable(jdbcTemplate, database, this, tableName);
+    }
+}

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaSchema.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaSchema.java
@@ -15,11 +15,13 @@
  */
 package org.flywaydb.community.database.kinetica;
 
+import org.flywaydb.community.database.ignite.thin.IgniteThinTable;
 import org.flywaydb.core.internal.database.base.Schema;
 import org.flywaydb.core.internal.database.base.Table;
 import org.flywaydb.core.internal.jdbc.JdbcTemplate;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class KineticaSchema extends Schema<KineticaDatabase,KineticaTable> {
@@ -58,7 +60,9 @@ public class KineticaSchema extends Schema<KineticaDatabase,KineticaTable> {
 
     @Override
     protected void doClean() throws SQLException {
-      //
+        for (Table table : allTables()) {
+            table.drop();
+        }
     }
 
     @Override

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaSchema.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaSchema.java
@@ -36,7 +36,7 @@ public class KineticaSchema extends Schema<KineticaDatabase,KineticaTable> {
 
     @Override
     protected boolean doExists() throws SQLException {
-        return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME=?", name) > 0;
+        return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME= '"+name+"'") > 0;
     }
 
     @Override
@@ -64,7 +64,7 @@ public class KineticaSchema extends Schema<KineticaDatabase,KineticaTable> {
     @Override
     protected KineticaTable[] doAllTables() throws SQLException {
         String query = "select table_name from information_schema.tables where table_schema= '"+name +"'";
-        List<String> tables = jdbcTemplate.queryForStringList(query, name);
+        List<String> tables = jdbcTemplate.queryForStringList(query);
         KineticaTable[]  kineticaTables = new KineticaTable[tables.size()];
         int index = 0;
         for (String table: tables) {

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaTable.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaTable.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.kinetica;
+
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+import java.sql.SQLException;
+
+public class KineticaTable extends Table<KineticaDatabase, KineticaSchema> {
+    /**
+     * @param jdbcTemplate The JDBC template for communicating with the DB.
+     * @param database     The database-specific support.
+     * @param schema       The schema this table lives in.
+     * @param name         The name of the table.
+     */
+    public KineticaTable(JdbcTemplate jdbcTemplate, KineticaDatabase database, KineticaSchema schema, String name) {
+        super(jdbcTemplate, database, schema, name);
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        return jdbcTemplate.queryForInt("select count(table_name) from information_schema.tables where table_schema= '"+schema.getName()+"'"
+                +"AND table_name ='"+name+"'"   ) > 0;
+    }
+
+    @Override
+    protected void doLock() throws SQLException {
+        // Kinetica does not do transaction locks.
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        jdbcTemplate.execute("DROP TABLE " + schema.getName()+"." +name );
+    }
+}

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaTable.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/kinetica/KineticaTable.java
@@ -46,6 +46,6 @@ public class KineticaTable extends Table<KineticaDatabase, KineticaSchema> {
 
     @Override
     protected void doDrop() throws SQLException {
-        jdbcTemplate.execute("DROP TABLE " + schema.getName()+"." +name );
+        jdbcTemplate.execute("DROP TABLE \"" + schema.getName()+"\".\"" +name+"\"" );
     }
 }

--- a/flyway-community-db-support/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
+++ b/flyway-community-db-support/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
@@ -2,3 +2,4 @@ org.flywaydb.community.database.ignite.thin.IgniteThinDatabaseType
 org.flywaydb.community.database.mysql.tidb.TiDBDatabaseType
 org.flywaydb.community.database.yugabytedb.YugabyteDBDatabaseType
 org.flywaydb.community.database.CommunityDatabaseExtension
+org.flywaydb.community.database.kinetica.KineticaDatabaseType


### PR DESCRIPTION
These changes are to support the Kinetica database.  Kinetica is a SQL based  data warehouse database  that does not support transaction processing.  In effect, there is no ability to commit or rollback.   
The instructions in https://flywaydb.org/documentation/contribute/contributingDatabaseSupport were followed. In a nutshell a new package folder for Kinetica was created with the corresponding classes being extended as per the documentation.  There were some variations where the documentation did not work. Instead, I followed the package IgniteLight  for the Apache Ignite database, which is quite similar in syntax.  Furthermore,   ExecutionTemplate had to be re-implemented into KineticaExecutionTemplate (i.e., override TransactionExecutionTemplate). Then KineticaExecutionTemplate is being used by KinetiaDatabaseType and overrides the method createTransactionalExecutionTemplate that is found in DatabaseType.  The reason for doing this is that TransactionExcutionTemplate tries to commit and rollback transactions and these actions do not exist in Kinetica so that action had overridden. 
Lastly, according to the documentation, the plugin is supposed to be added through
DatabaseTypeRegister.registerForDatabaseTypes add a registeredDatabaseTypes.add(new FooDatabaseType(classLoader)); line.
No such method was found anywhere.   However, adding the package in  src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin was all that was needed for the package to be registered and to make it work properly. 